### PR TITLE
allow 2 ipmen to have the same ip in their pool

### DIFF
--- a/restctl.Dockerfile
+++ b/restctl.Dockerfile
@@ -13,11 +13,11 @@ COPY api ./api
 
 RUN --mount=type=cache,target=/build GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o restctl ./cmd/restctl
 
-FROM nixos/nix
+FROM ubuntu:latest
 
 WORKDIR /
 
-RUN nix-env -iA nixpkgs.strongswan
+RUN apt update -y && apt install -y strongswan
 
 COPY --from=builder /workspace/restctl .
 


### PR DESCRIPTION
2 ipsec connections can have the sam ip in their pool since they are completely seperate with traffic going through xfrm for each child. Therefore this check is no longer necessary, i changed it to match child/ip pairs now since then there could be a problem. 