### PR TITLE
fix(restctl): scope children by connection and use --ike flag

### DIFF
--- a/cmd/restctl/main.go
+++ b/cmd/restctl/main.go
@@ -296,7 +296,7 @@ func getConfigs(w http.ResponseWriter, r *http.Request) {
 	v := NewReconcileVisitor(conns, sas)
 
 	json.NewEncoder(w).Encode(comms.ConfigRequest{
-		Conns: slices.Collect(maps.Keys(v.SasConnections)),
+		Conns: slices.Collect(maps.Keys(v.SasChildren)),
 		Error: nil,
 	})
 }
@@ -451,6 +451,17 @@ func RestartConnection(connName string, logger *slog.Logger) error {
 	return nil
 }
 
+// RestartChild attempts to restart a child connection
+func RestartChild(childName, connName string, logger *slog.Logger) error {
+	output, err := swanctl("--initiate", "--child", childName, "--ike", connName, "--timeout", "3")
+	if err != nil {
+		logger.Error("Failed to restart child connection", "child", childName, "conn", connName, "err", err, "output", output)
+		return fmt.Errorf("failed to restart child connection %s: %w", childName, err)
+	}
+	logger.Info("Successfully initiated child connection", "child", childName, "conn", connName, "output", output)
+	return nil
+}
+
 func reconcileIPSec(conns, sas *swanparse.SwanAST) error {
 	handler := slog.NewJSONHandler(os.Stdout, nil)
 	logger := slog.New(handler)
@@ -477,11 +488,13 @@ func reconcileIPSec(conns, sas *swanparse.SwanAST) error {
 		}
 
 		// Restart missing child connections
-		for child := range reconciler.MissingChildren {
-			if err := RestartConnection(child, logger); err != nil {
-				logger.Error("Error restarting child connection", "child", child, "err", err)
-			} else {
-				logger.Info("Successfully restarted child connection", "child", child)
+		for conn, children := range reconciler.MissingChildren {
+			for _, child := range children {
+				if err := RestartChild(child, conn, logger); err != nil {
+					logger.Error("Error restarting child connection", "child", child, "conn", conn, "err", err)
+				} else {
+					logger.Info("Successfully restarted child connection", "child", child, "conn", conn)
+				}
 			}
 		}
 	}

--- a/cmd/restctl/visitor.go
+++ b/cmd/restctl/visitor.go
@@ -7,10 +7,9 @@ import (
 // ReconcileVisitor identifies connections and children in conns that are not in sas
 type ReconcileVisitor struct {
 	Conns           *swanparse.SwanAST
-	SasConnections  map[string]bool
-	SasChildren     map[string]bool
+	SasChildren     map[string]map[string]bool
 	MissingConns    map[string]bool
-	MissingChildren map[string]bool
+	MissingChildren map[string][]string
 }
 
 func NewReconcileVisitor(conns, sas *swanparse.SwanAST) *ReconcileVisitor {
@@ -20,10 +19,9 @@ func NewReconcileVisitor(conns, sas *swanparse.SwanAST) *ReconcileVisitor {
 
 	return &ReconcileVisitor{
 		Conns:           conns,
-		SasConnections:  sasCollector.Connections,
 		SasChildren:     sasCollector.Children,
 		MissingConns:    make(map[string]bool),
-		MissingChildren: make(map[string]bool),
+		MissingChildren: make(map[string][]string),
 	}
 }
 
@@ -50,13 +48,13 @@ func (r *ReconcileVisitor) VisitEntry(entry *swanparse.Entry) error {
 // Override VisitConn to check if connection exists in SAs
 func (r *ReconcileVisitor) VisitConn(conn *swanparse.Conn) error {
 	// Check if this connection exists in sas
-	if !r.SasConnections[conn.Name] {
+	if _, ok := r.SasChildren[conn.Name]; !ok {
 		r.MissingConns[conn.Name] = true
 	}
 
 	// Process child entities in the connection body
 	for _, entity := range conn.Body {
-		if err := r.VisitEntity(entity); err != nil {
+		if err := r.VisitEntity(entity, conn); err != nil {
 			return err
 		}
 	}
@@ -64,31 +62,37 @@ func (r *ReconcileVisitor) VisitConn(conn *swanparse.Conn) error {
 }
 
 // Override VisitEntity to ensure we call our methods
-func (r *ReconcileVisitor) VisitEntity(entity *swanparse.Entity) error {
+func (r *ReconcileVisitor) VisitEntity(entity *swanparse.Entity, conn *swanparse.Conn) error {
 	if entity.Block != nil {
-		return r.VisitBlock(entity.Block)
+		return r.VisitBlock(entity.Block, conn)
 	}
 	if entity.Option != nil {
-		return r.VisitOption(entity.Option)
+		return r.VisitOption(entity.Option, conn)
 	}
 	return nil
 }
 
 // Override VisitOption with empty implementation
-func (r *ReconcileVisitor) VisitOption(option *swanparse.Option) error {
+func (r *ReconcileVisitor) VisitOption(option *swanparse.Option, conn *swanparse.Conn) error {
 	return nil
 }
 
 // Override VisitBlock to check if children exist in SAs
-func (r *ReconcileVisitor) VisitBlock(block *swanparse.Block) error {
+func (r *ReconcileVisitor) VisitBlock(block *swanparse.Block, conn *swanparse.Conn) error {
 	// When encountering a children block in the connection AST,
 	// check if each child exists in the SAs
 	if block.Name == "children" {
 		for _, childEntity := range block.Body {
 			if childEntity.Block != nil {
 				childName := childEntity.Block.Name
-				if !r.SasChildren[childName] {
-					r.MissingChildren[childName] = true
+				exists := false
+				if children, ok := r.SasChildren[conn.Name]; ok {
+					if children[childName] {
+						exists = true
+					}
+				}
+				if !exists {
+					r.MissingChildren[conn.Name] = append(r.MissingChildren[conn.Name], childName)
 				}
 			}
 		}
@@ -96,7 +100,7 @@ func (r *ReconcileVisitor) VisitBlock(block *swanparse.Block) error {
 
 	// Process all entities in the block
 	for _, entity := range block.Body {
-		if err := r.VisitEntity(entity); err != nil {
+		if err := r.VisitEntity(entity, conn); err != nil {
 			return err
 		}
 	}

--- a/pkg/swanparse/visitor.go
+++ b/pkg/swanparse/visitor.go
@@ -5,21 +5,19 @@ type SwanASTVisitor interface {
 	VisitAST(ast *SwanAST) error
 	VisitEntry(entry *Entry) error
 	VisitConn(conn *Conn) error
-	VisitEntity(entity *Entity) error
-	VisitBlock(block *Block) error
-	VisitOption(option *Option) error
+	VisitEntity(entity *Entity, conn *Conn) error
+	VisitBlock(block *Block, conn *Conn) error
+	VisitOption(option *Option, conn *Conn) error
 }
 
-// ConnectionCollector collects all connection names
+// ConnectionCollector collects all connection names and children
 type ConnectionCollector struct {
-	Connections map[string]bool
-	Children    map[string]bool
+	Children map[string]map[string]bool
 }
 
 func NewConnectionCollector() *ConnectionCollector {
 	return &ConnectionCollector{
-		Connections: make(map[string]bool),
-		Children:    make(map[string]bool),
+		Children: make(map[string]map[string]bool),
 	}
 }
 
@@ -43,13 +41,15 @@ func (c *ConnectionCollector) VisitEntry(entry *Entry) error {
 	return nil
 }
 
-// Override VisitConn to collect connection names
+// Override VisitConn to collect connection names and initialize children map
 func (c *ConnectionCollector) VisitConn(conn *Conn) error {
-	c.Connections[conn.Name] = true
+	if c.Children[conn.Name] == nil {
+		c.Children[conn.Name] = make(map[string]bool)
+	}
 
 	// Process child entities in the connection body
 	for _, entity := range conn.Body {
-		if err := c.VisitEntity(entity); err != nil {
+		if err := c.VisitEntity(entity, conn); err != nil {
 			return err
 		}
 	}
@@ -57,23 +57,23 @@ func (c *ConnectionCollector) VisitConn(conn *Conn) error {
 }
 
 // Override VisitEntity to ensure we call our methods
-func (c *ConnectionCollector) VisitEntity(entity *Entity) error {
+func (c *ConnectionCollector) VisitEntity(entity *Entity, conn *Conn) error {
 	if entity.Block != nil {
-		return c.VisitBlock(entity.Block)
+		return c.VisitBlock(entity.Block, conn)
 	}
 	if entity.Option != nil {
-		return c.VisitOption(entity.Option)
+		return c.VisitOption(entity.Option, conn)
 	}
 	return nil
 }
 
 // Override VisitOption with empty implementation
-func (c *ConnectionCollector) VisitOption(option *Option) error {
+func (c *ConnectionCollector) VisitOption(option *Option, conn *Conn) error {
 	return nil
 }
 
 // Override VisitBlock to collect children information
-func (c *ConnectionCollector) VisitBlock(block *Block) error {
+func (c *ConnectionCollector) VisitBlock(block *Block, conn *Conn) error {
 	// Look for child-sas blocks (in SA listings)
 	if block.Name == "child-sas" {
 		for _, entity := range block.Body {
@@ -82,7 +82,8 @@ func (c *ConnectionCollector) VisitBlock(block *Block) error {
 				for _, childEntity := range entity.Block.Body {
 					if childEntity.Option != nil && childEntity.Option.Key == "name" &&
 						childEntity.Option.Value != nil && childEntity.Option.Value.Single != nil {
-						c.Children[*childEntity.Option.Value.Single] = true
+						childName := *childEntity.Option.Value.Single
+						c.Children[conn.Name][childName] = true
 						break
 					}
 				}
@@ -92,14 +93,15 @@ func (c *ConnectionCollector) VisitBlock(block *Block) error {
 	} else if block.Name == "children" {
 		for _, entity := range block.Body {
 			if entity.Block != nil {
-				c.Children[entity.Block.Name] = true
+				childName := entity.Block.Name
+				c.Children[conn.Name][childName] = true
 			}
 		}
 	}
 
 	// Process all entities in the block
 	for _, entity := range block.Body {
-		if err := c.VisitEntity(entity); err != nil {
+		if err := c.VisitEntity(entity, conn); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Refactors ConnectionCollector and ReconcileVisitor to track IPsec children within the scope of their parent connection, resolving issues with duplicate child names. Adds the --ike flag to child initiation commands to ensure the correct parent connection is targeted.
