### PR TITLE
fix(chart): drop duplicate app.kubernetes.io/name key from ipman.labels

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -37,7 +37,6 @@ Common labels
 helm.sh/chart: {{ include "ipman.chart" . }}
 {{ include "ipman.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/name: {{ include "ipman.name" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
`ipman.labels` already includes `ipman.selectorLabels` above, which
unconditionally sets `app.kubernetes.io/name`. The `if .Chart.AppVersion`
block then sets the same key again, so every resource using this helper
(deployment.yaml's `metadata.labels` and `spec.template.metadata.labels`)
ends up with the key defined twice in one YAML mapping.

Plain `helm install`/`kubectl` tolerate this silently (lenient
YAML->JSON decoding, last duplicate wins), but installing via Flux's
helm-controller fails outright, since its post-render step uses a
stricter decoder:

    error while running post render on files: ... mapping key
    "app.kubernetes.io/name" already defined
