### PR TITLE
fix(vxlandlord): add bridge fdb entry via netlink instead of shelling out to bridge

### DIFF
--- a/cmd/vxlandlord/main.go
+++ b/cmd/vxlandlord/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"dialo.ai/ipman/pkg/netconfig"
 	u "dialo.ai/ipman/pkg/utils"
 	ip "github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func createVxlan(underlying *ip.Link, local_ip net.IP, id int) (*ip.Link, error) {
@@ -113,8 +113,18 @@ func main() {
 			"Error preparing ip address to append to bridge fdb",
 		)
 	}
-	cmd := exec.Command("bridge", "fdb", "append", "00:00:00:00:00:00", "dev", "vxlan"+strconv.FormatInt(int64(ifId), 10), "dst", xfrmUnderlyingIp)
-	_, err = cmd.Output()
+	// Equivalent to: bridge fdb append 00:00:00:00:00:00 dev vxlanN dst <xfrmUnderlyingIp>
+	// Done via netlink directly rather than shelling out to the external `bridge`
+	// binary, which is not guaranteed to be present in the container image.
+	fdbEntry := &ip.Neigh{
+		LinkIndex:    (*vxlan).Attrs().Index,
+		Family:       unix.AF_BRIDGE,
+		Flags:        ip.NTF_SELF,
+		State:        ip.NUD_PERMANENT,
+		IP:           net.ParseIP(xfrmUnderlyingIp),
+		HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 0},
+	}
+	err = ip.NeighAppend(fdbEntry)
 	u.Fatal(err, logger, "Error appending to bridge fdb")
 
 	dstWithFullMask := net.IPNet{IP: xfrm_ipnet.IP, Mask: net.CIDRMask(32, 32)}

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.11.0 // indirect


### PR DESCRIPTION
The iface-request init container crashes on startup with
"Error appending to bridge fdb: exec: \"bridge\": executable file not
found in $PATH" because the vxlandlord image does not install iproute2,
so the external `bridge` binary this code shells out to is never
present. Every other network operation in this file (link/addr/route
management) already goes through vishvananda/netlink directly - this
was the one exception.

Replaces the `bridge fdb append` exec.Command call with an equivalent
netlink.NeighAppend (family AF_BRIDGE, NTF_SELF, NUD_PERMANENT),
removing the dependency on the external binary entirely rather than
just adding iproute2 to the image.
