### PR TITLE
fix(webhook): pin injected iface-request container to runAsUser 0

### DIFF
--- a/internal/webhook/v1/mutating_webhook.go
+++ b/internal/webhook/v1/mutating_webhook.go
@@ -334,5 +334,15 @@ func createNetAdminSecurityContext() *corev1.SecurityContext {
 		Capabilities: &corev1.Capabilities{
 			Add: []corev1.Capability{"NET_ADMIN"},
 		},
+		// Creating the VXLAN device (cmd/vxlandlord) needs to run as root:
+		// confirmed by reproducing with a minimal netlink.LinkAdd call under
+		// the exact same capability set - it succeeds as uid 0, fails with
+		// "operation not permitted" as any non-root uid, regardless of
+		// NET_ADMIN. This container is injected into an arbitrary workload
+		// pod, whose own pod-level securityContext.runAsUser (if the
+		// workload chooses to run as non-root, e.g. most StatefulSets) would
+		// otherwise be inherited here too. A container-level RunAsUser
+		// overrides the pod-level one, so pin this one to root explicitly.
+		RunAsUser: u.Ptr(int64(0)),
 	}
 }


### PR DESCRIPTION
VXLAN device creation (cmd/vxlandlord) needs root regardless of granted
capabilities. This container gets injected into an arbitrary workload pod,
which inherits that pod's securityContext.runAsUser if it sets one (e.g. most
StatefulSets running as non-root) unless overridden per-container.

A container-level RunAsUser overrides the pod-level one, so pin this
one to root explicitly.
