### PR TITLE
fix/webhook runasnonroot stack

### DIFF
--- a/internal/controller/ipman_controller.go
+++ b/internal/controller/ipman_controller.go
@@ -367,7 +367,7 @@ func (r *IPSecConnectionReconciler) GetWorkersState(ctx context.Context) (*Worke
 func (r *IPSecConnectionReconciler) GetClusterState(ctx context.Context) (*ClusterState, error) {
 	cs := &ClusterState{
 		Groups:     []GroupState{},
-		PodMonitor: true,
+		PodMonitor: false,
 	}
 	groups := ipmanv1.CharonGroupList{}
 	err := r.List(ctx, &groups)
@@ -375,12 +375,14 @@ func (r *IPSecConnectionReconciler) GetClusterState(ctx context.Context) (*Clust
 		return nil, &RequestError{"List", "CharonGroups", err}
 	}
 
-	pm := &promv1.PodMonitor{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: r.Env.NamespaceName, Name: ipmanv1.PodMonitorRestctlName}, pm)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, &RequestError{"Get", "PodMonitor", err}
-		} else {
+	if r.Env.IsMonitoringEnabled {
+		cs.PodMonitor = true
+		pm := &promv1.PodMonitor{}
+		err = r.Get(ctx, types.NamespacedName{Namespace: r.Env.NamespaceName, Name: ipmanv1.PodMonitorRestctlName}, pm)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, &RequestError{"Get", "PodMonitor", err}
+			}
 			cs.PodMonitor = false
 		}
 	}

--- a/internal/webhook/v1/mutating_webhook.go
+++ b/internal/webhook/v1/mutating_webhook.go
@@ -334,15 +334,8 @@ func createNetAdminSecurityContext() *corev1.SecurityContext {
 		Capabilities: &corev1.Capabilities{
 			Add: []corev1.Capability{"NET_ADMIN"},
 		},
-		// Creating the VXLAN device (cmd/vxlandlord) needs to run as root:
-		// confirmed by reproducing with a minimal netlink.LinkAdd call under
-		// the exact same capability set - it succeeds as uid 0, fails with
-		// "operation not permitted" as any non-root uid, regardless of
-		// NET_ADMIN. This container is injected into an arbitrary workload
-		// pod, whose own pod-level securityContext.runAsUser (if the
-		// workload chooses to run as non-root, e.g. most StatefulSets) would
-		// otherwise be inherited here too. A container-level RunAsUser
-		// overrides the pod-level one, so pin this one to root explicitly.
-		RunAsUser: u.Ptr(int64(0)),
+
+		RunAsUser:    u.Ptr(int64(0)),
+		RunAsNonRoot: u.Ptr(false),
 	}
 }

--- a/internal/webhook/v1/mutating_webhook.go
+++ b/internal/webhook/v1/mutating_webhook.go
@@ -334,5 +334,15 @@ func createNetAdminSecurityContext() *corev1.SecurityContext {
 		Capabilities: &corev1.Capabilities{
 			Add: []corev1.Capability{"NET_ADMIN"},
 		},
+		// Creating the VXLAN device (cmd/vxlandlord) needs to run as root:
+		// confirmed by reproducing with a minimal netlink.LinkAdd call under
+		// the exact same capability set - it succeeds as uid 0, fails with
+		// "operation not permitted" as any non-root uid, regardless of
+		// NET_ADMIN. This container is injected into an arbitrary workload
+		// pod, whose own pod-level securityContext.runAsUser (if the
+		// workload chooses to run as non-root, e.g. most StatefulSets) would
+		// otherwise be inherited here too. A container-level RunAsUser
+		// overrides the pod-level one, so pin this one to root explicitly.
+		RunAsUser: u.Ptr(int64(0)),
 	}
 }


### PR DESCRIPTION
- **fix(webhook): pin injected iface-request container to runAsUser 0**
- **fix(init-container): override runAsNonRoot per container**
- **fix(monitoring): dont query podmonitor if monitoring is disabled**
